### PR TITLE
Fix tab/tables.pl for Perl 5.26

### DIFF
--- a/tab/tables.pl
+++ b/tab/tables.pl
@@ -3,7 +3,7 @@
 # Copyright 2001 Abhijit Menon-Sen <ams@wiw.org>
 
 use strict;
-require 'tab/misc.pl';
+require './tab/misc.pl';
 
 my ($qtab, $mtab) = ([], []);
 


### PR DESCRIPTION
Removal of "." from @INC means require $PATH no longer ever assumes
a path relative to ".", and instead must be explicitly stated with a
leading "./"

Fixes RT#120087

Bug: https://rt.cpan.org/Ticket/Display.html?id=120087